### PR TITLE
client supports "Close"

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -14,6 +14,7 @@ import (
 // Client .
 type Client interface {
 	Info(context.Context) (types.HostInfo, error)
+	Close() error
 	GetGuest(ctx context.Context, ID string) (types.Guest, error)
 	GetGuestUUID(ctx context.Context, ID string) (string, error)
 	GetGuestIDList(ctx context.Context, args types.GetGuestIDListReq) ([]string, error)


### PR DESCRIPTION
发现core里的engine cache checker创建太多连接可能会内存泄漏，所以提供一个Close方法用于手动关闭连接。

对于gRPC client来说，没法手动关闭连接，所以加了个缓存用来保证多个请求复用同一个stub。